### PR TITLE
Bump FMP version to 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <camel.version>2.21.2</camel.version>
 
         <!-- versions of Maven plugins -->
-        <fmp.version>3.5.40</fmp.version>
+        <fmp.version>4.0.0</fmp.version>
 
         <!-- version of Arquillian -->
         <arquillian.cube.version>1.17.1</arquillian.cube.version>


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

This PR bumps FMP version to 4.0.0 to make it possible to deploy this sample on OpenShift 4