### PR TITLE
[ENTESB-18864] Update Boosters on launch.openshift.io to 7.10.2

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 :launchURL: https://developers.redhat.com/launch
 :image-registry: registry.access.redhat.com
 :image-prefix: /fuse7/
-:image-name-version: fuse-java-openshift-rhel8:1.10
+:image-name-version: fuse-java-openshift-rhel8:1.10-25
 
 = Externalized Configuration - Fuse Booster
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.redhat.fuse.boosters</groupId>
     <artifactId>fuse-configmap-booster</artifactId>
-    <version>7.0.0.fuse-sb2-7_10_2-00002</version>
+    <version>7.0.0.fuse-sb2-7_10_2-00001</version>
 
     <name>Fuse :: Boosters :: Configmap</name>
 
@@ -13,8 +13,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <fuse.bom.version>7.10.0.fuse-sb2-7_10_2-00001</fuse.bom.version>
-        <docker.image.version>registry.redhat.io/fuse7/fuse-java-openshift-rhel8:1.10</docker.image.version>
+        <fuse.bom.version>7.10.0.fuse-sb2-7_10_2-00001-redhat-00002</fuse.bom.version>
+        <docker.image.version>registry.redhat.io/fuse7/fuse-java-openshift-rhel8:1.10-25</docker.image.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-18864

Using latest image and BOM versions.