### PR TITLE
[ENTESB-22733] Update Boosters on launch.openshift.io to 7.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <fuse.bom.version>7.12.0.fuse-7_12_0-00016-redhat-00001</fuse.bom.version>
+        <fuse.bom.version>7.13.0.fuse-7_13_0-00012-redhat-00001</fuse.bom.version>
         <docker.image.version>registry.redhat.io/fuse7/fuse-java-openshift-rhel8:1.13</docker.image.version>
 
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-22733

https://maven.repository.redhat.com/ga/org/jboss/redhat-fuse/redhat-fuse/7.13.0.fuse-7_13_0-00012-redhat-00001/